### PR TITLE
fix NaN loss by replacing with 0

### DIFF
--- a/bert_multitask_learning/model_fn.py
+++ b/bert_multitask_learning/model_fn.py
@@ -201,8 +201,6 @@ class BertMultiTask():
 
                 top_scope_name = self.get_scope_name(problem)
 
-                # WARNING: Potential nan created here!
-                # TODO: Fix this.
                 if len(self.params.run_problem_list) > 1:
                     feature_this_round, hidden_feature_this_round = self.get_features_for_problem(
                         features, hidden_feature, problem, mode)

--- a/bert_multitask_learning/top.py
+++ b/bert_multitask_learning/top.py
@@ -142,6 +142,9 @@ class Classification(TopLayer):
             batch_loss = self.create_batch_loss(labels, logits, num_classes)
             self.loss = self.create_loss(
                 batch_loss, features['%s_loss_multiplier' % problem_name])
+            # If a batch does not contain input instances from the current problem, the loss multiplier will be empty
+            # and loss will be NaN. Replacing NaN with 0 fixes the problem.
+            self.loss = tf.where(tf.math.is_nan(self.loss), tf.zeros_like(self.loss), self.loss)
             return self.loss
         elif mode == tf.estimator.ModeKeys.EVAL:
             labels = features['%s_label_ids' % problem_name]

--- a/bert_multitask_learning/top.py
+++ b/bert_multitask_learning/top.py
@@ -72,6 +72,9 @@ class SequenceLabel(TopLayer):
                 logits, seq_labels, seq_length, crf_transition_param)
             self.loss = self.create_loss(
                 batch_loss, features['%s_loss_multiplier' % problem_name])
+            # If a batch does not contain input instances from the current problem, the loss multiplier will be empty
+            # and loss will be NaN. Replacing NaN with 0 fixes the problem.
+            self.loss = tf.where(tf.math.is_nan(self.loss), tf.zeros_like(self.loss), self.loss)
             return self.loss
 
         elif mode == tf.estimator.ModeKeys.EVAL:
@@ -424,6 +427,9 @@ class Seq2Seq(TopLayer):
                 shift_labels, logits)
             loss = self.create_loss(
                 batch_loss, features['%s_loss_multiplier' % problem_name])
+            # If a batch does not contain input instances from the current problem, the loss multiplier will be empty
+            # and loss will be NaN. Replacing NaN with 0 fixes the problem.
+            self.loss = tf.where(tf.math.is_nan(self.loss), tf.zeros_like(self.loss), self.loss)
             self.loss = loss
 
             if mode == tf.estimator.ModeKeys.TRAIN:
@@ -481,6 +487,9 @@ class MultiLabelClassification(TopLayer):
             batch_loss = self.create_batch_loss(labels, logits, num_classes)
             self.loss = self.create_loss(
                 batch_loss, features['%s_loss_multiplier' % problem_name])
+            # If a batch does not contain input instances from the current problem, the loss multiplier will be empty
+            # and loss will be NaN. Replacing NaN with 0 fixes the problem.
+            self.loss = tf.where(tf.math.is_nan(self.loss), tf.zeros_like(self.loss), self.loss)
             return self.loss
         elif mode == tf.estimator.ModeKeys.EVAL:
             labels = features['%s_label_ids' % problem_name]


### PR DESCRIPTION
NaN loss is generated when a batch does not contain instances from all tasks. For those tasks which are not present in a batch, the loss_multiplier will be an empty tensor, which produces NaN when the batch_loss is multiplied by the (empty) loss multiplier. Replace with 0 to fix the issue.